### PR TITLE
Fix aarch64-linux memory corruption in scanner.c

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 packages:
     ./haskell-arborist.cabal
-    ./haskell-bullseye/haskell-bullseye.cabal
+    --./haskell-bullseye/haskell-bullseye.cabal
 --    ../tree-sitter-simple/tree-sitter-simple
 --    ../tree-sitter-simple/tree-sitter-haskell
 --    ../tree-sitter-simple/tree-sitter-ast
@@ -10,7 +10,7 @@ packages:
 source-repository-package
     type: git
     location: https://github.com/tfausak/tree-sitter-simple.git
-    tag: 792959489fd25c2e1dc3e5a3502726aae7c84cee
+    tag: 3457a96146d2f637ccf3789ba6dd9ef770bdc052
     subdir:
       tree-sitter-simple
       tree-sitter-haskell

--- a/cabal.project
+++ b/cabal.project
@@ -9,8 +9,8 @@ packages:
 
 source-repository-package
     type: git
-    location: https://github.com/josephsumabat/tree-sitter-simple.git
-    tag: 1d280ff9335f3e53a9accebb66c92e6a3ca389b1
+    location: https://github.com/tfausak/tree-sitter-simple.git
+    tag: 792959489fd25c2e1dc3e5a3502726aae7c84cee
     subdir:
       tree-sitter-simple
       tree-sitter-haskell

--- a/cabal.project
+++ b/cabal.project
@@ -9,8 +9,8 @@ packages:
 
 source-repository-package
     type: git
-    location: https://github.com/tfausak/tree-sitter-simple.git
-    tag: 8dbbdf2d504ebd9a34ca131987d2a288387c9b14
+    location: https://github.com/josephsumabat/tree-sitter-simple.git
+    tag: a97da04ac45ff4199fe845d1debd56a4a3d4f038
     subdir:
       tree-sitter-simple
       tree-sitter-haskell

--- a/cabal.project
+++ b/cabal.project
@@ -10,7 +10,7 @@ packages:
 source-repository-package
     type: git
     location: https://github.com/tfausak/tree-sitter-simple.git
-    tag: 3457a96146d2f637ccf3789ba6dd9ef770bdc052
+    tag: 8dbbdf2d504ebd9a34ca131987d2a288387c9b14
     subdir:
       tree-sitter-simple
       tree-sitter-haskell

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,9 +1,9 @@
 # Keep this up to date with cabal.project
 let
   tree-sitter-simple-repo = {
-    url = "https://github.com/tfausak/tree-sitter-simple";
-    sha256 = "sha256-Lt98k0f6PK0CKo6onXzIWd6fVNKZKvxH/zoEzKFpWMQ=";
-    rev = "8dbbdf2d504ebd9a34ca131987d2a288387c9b14";
+    url = "https://github.com/josephsumabat/tree-sitter-simple";
+    sha256 = "sha256-fY777r1TvqS17Gz5Ew2syWO7gYGmXRLaCMzvYWJwWYk=";
+    rev = "a97da04ac45ff4199fe845d1debd56a4a3d4f038";
     fetchSubmodules = true;
   };
 

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -2,8 +2,8 @@
 let
   tree-sitter-simple-repo = {
     url = "https://github.com/tfausak/tree-sitter-simple";
-    sha256 = "sha256-jyu3musWGpmLvm0Uf0BW2LxBInMmHoWowofmCtAspG4=";
-    rev = "3457a96146d2f637ccf3789ba6dd9ef770bdc052";
+    sha256 = "sha256-Lt98k0f6PK0CKo6onXzIWd6fVNKZKvxH/zoEzKFpWMQ=";
+    rev = "8dbbdf2d504ebd9a34ca131987d2a288387c9b14";
     fetchSubmodules = true;
   };
 

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,9 +1,9 @@
 # Keep this up to date with cabal.project
 let
   tree-sitter-simple-repo = {
-    url = "https://github.com/josephsumabat/tree-sitter-simple";
-    sha256 = "sha256-ijI9t56Mzxo+b7Y5HY3TM/LsMxnPyyokrGBCABFaFQo=";
-    rev = "1d280ff9335f3e53a9accebb66c92e6a3ca389b1";
+    url = "https://github.com/tfausak/tree-sitter-simple";
+    sha256 = "sha256-AKi63Trf9FCDu7QOfRBinuEKYefF/p4rali4qNdrlnI=";
+    rev = "792959489fd25c2e1dc3e5a3502726aae7c84cee";
     fetchSubmodules = true;
   };
 

--- a/test-data/auto-import/TestTypes.hs
+++ b/test-data/auto-import/TestTypes.hs
@@ -15,8 +15,6 @@ class MyClass a where
 
 newtype MyNewtype = MyNewtype Int
 
-type MyType = Int
-
 data MyData
   = MyDataConstructor Int String
 

--- a/test/Arborist/AutoImportSpec.hs
+++ b/test/Arborist/AutoImportSpec.hs
@@ -79,7 +79,7 @@ spec = do
       let [importingProg] = importingPrograms
           [exportProg] = exportPrograms
           importNode = Parse.findNode (AST.cast @H.ImportP) (AST.getDynNode importingProg.node)
-          dataDecl = (getDecls exportProg) !! 3
+          dataDecl = (getDecls exportProg) !! 2
 
       case importNode of
         Just import' -> do
@@ -98,7 +98,7 @@ spec = do
       let [importingProg] = importingPrograms
           [exportProg] = exportPrograms
           importNode = Parse.findNode (AST.cast @H.ImportP) (AST.getDynNode importingProg.node)
-          fooDecl = (getDecls exportProg) !! 4
+          fooDecl = (getDecls exportProg) !! 3
 
       case importNode of
         Just import' -> do
@@ -117,7 +117,7 @@ spec = do
       let [importingProg] = importingPrograms
           [exportProg] = exportPrograms
           importNode = Parse.findNode (AST.cast @H.ImportP) (AST.getDynNode importingProg.node)
-          operatorDecl = (getDecls exportProg) !! 6
+          operatorDecl = (getDecls exportProg) !! 5
 
       case importNode of
         Just import' -> do


### PR DESCRIPTION
See #11 and https://github.com/josephsumabat/tree-sitter-simple/pull/3.

---

Update tree-sitter-simple source to tfausak's fork at 792959489fd25c2e1dc3e5a3502726aae7c84cee, which updates the tree-sitter-haskell submodule to incorporate the fix from https://github.com/tree-sitter/tree-sitter-haskell/pull/151.

The fix stores the lexer lookahead in a temporary variable before passing it to array_push, preventing undefined behavior from unspecified argument evaluation order at higher optimization levels (-O2) on aarch64-linux.

See: https://github.com/josephsumabat/tree-sitter-simple/pull/3